### PR TITLE
[CI/CD] Call Awesome Lint Directly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,4 +55,4 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
         with:
           fetch-depth: 0
-      - uses: max/awesome-lint@v2.0.0
+      - run: npx awesome-lint


### PR DESCRIPTION
## Description

With the latest update of awesome-lint, the awesome-lint action was rendered useless, as it uses node 10, and the update requires node 18+.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing 🧑‍🌾
- [x] Only awesome is awesome 🕶️
